### PR TITLE
fix dhcpcd typo

### DIFF
--- a/archfi
+++ b/archfi
@@ -819,7 +819,7 @@ archmenu(){
   options+=("${txtedit//%1/mkinitcpio.conf}" "($txtoptional)")
   options+=("${txtedit//%1/mirrorlist}" "($txtoptional)")
   options+=("$txtbootloader" "")
-  options+=("${txtenable//%1/dhcpcd}" "systemctl enable dhcpd")
+  options+=("${txtenable//%1/dhcpcd}" "systemctl enable dhcpcd")
   options+=("archdi" "$txtarchdidesc")
   sel=$(whiptail --backtitle "$apptitle" --title "$txtarchinstallmenu" --menu "" --cancel-button "$txtback" --default-item "$nextitem" 0 0 0 \
     "${options[@]}" \
@@ -971,7 +971,7 @@ archsetkeymap(){
 
 archsetfont(){
   items=$(find /usr/share/kbd/consolefonts/*.psfu.gz -printf "%f\n")
-  
+
   options=()
   for item in $items; do
     options+=("${item%%.*}" "")
@@ -1031,8 +1031,8 @@ archsettime(){
   if [ ! "$?" = "0" ]; then
     return 1
   fi
-  
-  
+
+
   items=$(ls /mnt/usr/share/zoneinfo/$timezone/)
   options=()
   for item in $items; do
@@ -1045,12 +1045,12 @@ archsettime(){
   if [ ! "$?" = "0" ]; then
     return 1
   fi
-  
+
   clear
   echo "ln -sf /mnt/usr/share/zoneinfo/$timezone /mnt/etc/localtime"
   ln -sf /usr/share/zoneinfo/$timezone /mnt/etc/localtime
   pressanykey
-  
+
   if (whiptail --backtitle "$apptitle" --title "$txtsettime" --yesno "$txtuseutcclock" 0 0) then
     clear
     archchroot settimeutc
@@ -1058,9 +1058,9 @@ archsettime(){
     clear
     archchroot settimelocal
   fi
-  
+
   pressanykey
-  
+
 }
 archsettimeutcchroot(){
   echo "hwclock --systohc --utc"
@@ -1223,7 +1223,7 @@ archgrubinstall(){
   echo "pacstrap /mnt grub"
   pacstrap /mnt grub
   pressanykey
-  
+
   if [ "$eficomputer" == "1" ]; then
     if [ "$efimode" == "1" ]||[ "$efimode" == "2" ]; then
       if (whiptail --backtitle "$apptitle" --title "${txtinstall//%1/efibootmgr}" --yesno "$txtefibootmgr" 0 0) then
@@ -1241,7 +1241,7 @@ archgrubinstall(){
       fi
     fi
   fi
-  
+
   if [ "$luksroot" = "1" ]; then
     if (whiptail --backtitle "$apptitle" --title "${txtinstall//%1/grub}" --yesno "$txtgrubluksdetected" 0 0) then
       clear
@@ -1250,7 +1250,7 @@ archgrubinstall(){
       pressanykey
     fi
   fi
-  
+
   clear
   archchroot grubinstall
   pressanykey
@@ -1375,12 +1375,12 @@ archbootloadersyslinuxbmenu(){
 }
 archsyslinuxinstall(){
   clear
-  
+
   if [ "$efimode" == "1" ]||[ "$efimode" == "2" ]; then
     echo "$txtsyslinuxaddefibootmgr"
     additionalpkg=$additionalpkg"efibootmgr "
   fi
-  
+
   if [ "$isnvme" = "1" ]; then
     if [ "$(parted ${realrootdev::(-2)} print|grep gpt)" != "" ]; then
       echo "$txtsyslinuxaddgptfdisk"
@@ -1392,7 +1392,7 @@ archsyslinuxinstall(){
       additionalpkg=$additionalpkg"gptfdisk "
     fi
   fi
-  
+
   if [ "$bootdev" != "" ]; then
     if [ "$(parted $bootdev print|grep fat)" != "" ]; then
       echo "$txtsyslinuxaddmtools"
@@ -1413,7 +1413,7 @@ archsyslinuxinstall(){
     echo "sed -i \"/APPEND\ root=/c\    APPEND root=$rootdev rw\" /mnt/boot/syslinux/syslinux.cfg"
     sed -i "/APPEND\ root=/c\    APPEND root=$rootdev\ rw" /mnt/boot/syslinux/syslinux.cfg
   fi
-  
+
   pressanykey
 }
 archsyslinuxinstallbootloader(){
@@ -1487,10 +1487,10 @@ archbootloadersystemdbmenu(){
 archsystemdinstall(){
   clear
   archchroot systemdbootloaderinstall $realrootdev
-  
+
   partuuid=$(blkid -s PARTUUID -o value $realrootdev)
   parttype=$(blkid -s TYPE -o value $rootdev)
-  
+
   echo "cp /mnt/usr/share/systemd/bootctl/arch.conf /mnt/boot/loader/entries"
   echo "echo \"timeout 2\" >> /mnt/boot/loader/loader.conf"
   echo "cp /mnt/usr/share/systemd/bootctl/loader.conf /mnt/boot/loader"
@@ -1506,12 +1506,12 @@ archsystemdinstall(){
   echo "cp /mnt/boot/loader/entries/arch.conf /mnt/boot/loader/entries/arch-fallback.conf"
   echo "sed -i \"s/Arch Linux/Arch Linux Fallback/\" /mnt/boot/loader/entries/arch-fallback.conf"
   echo "sed -i \"s/initramfs-linux/initramfs-linux-fallback/\" /mnt/boot/loader/entries/arch-fallback.conf"
-  
+
   cp /mnt/usr/share/systemd/bootctl/loader.conf /mnt/boot/loader
   echo "timeout 2" >> /mnt/boot/loader/loader.conf
   cp /mnt/usr/share/systemd/bootctl/arch.conf /mnt/boot/loader/entries
-  
-  
+
+
   if [ "$luksroot" = "1" ]; then
     sed -i "s/PARTUUID=XXXX/\/dev\/mapper\/root/" /mnt/boot/loader/entries/arch.conf
     sed -i "s/XXXX/$parttype/" /mnt/boot/loader/entries/arch.conf
@@ -1520,11 +1520,11 @@ archsystemdinstall(){
     sed -i "s/PARTUUID=XXXX/PARTUUID=$partuuid/" /mnt/boot/loader/entries/arch.conf
     sed -i "s/XXXX/$parttype/" /mnt/boot/loader/entries/arch.conf
   fi
-  
+
   cp /mnt/boot/loader/entries/arch.conf /mnt/boot/loader/entries/arch-fallback.conf
   sed -i "s/Arch Linux/Arch Linux Fallback/" /mnt/boot/loader/entries/arch-fallback.conf
   sed -i "s/initramfs-linux/initramfs-linux-fallback/" /mnt/boot/loader/entries/arch-fallback.conf
-  
+
   pressanykey
 }
 archsystemdinstallchroot(){
@@ -1567,13 +1567,13 @@ archbootloaderrefindmenu(){
 }
 archrefindinstall(){
   clear
-  
+
   echo "pacstrap /mnt refind-efi"
   echo "archchroot refindbootloaderinstall $realrootdev"
   echo "echo \"\\\"Arch Linux         \\\" \\\"root=UUID=$rootuuid rw add_efi_memmap\\\"\" > /mnt/boot/refind_linux.conf"
   echo "echo \"\\\"Arch Linux Fallback\\\" \\\"root=UUID=$rootuuid rw add_efi_memmap initrd=/initramfs-linux-fallback.img\\\"\" >> /mnt/boot/refind_linux.conf"
   echo "echo \"\\\"Arch Linux Terminal\\\" \\\"root=UUID=$rootuuid rw add_efi_memmap systemd.unit=multi-user.target\\\"\" >> /mnt/boot/refind_linux.conf"
-  
+
   pacstrap /mnt refind-efi
   archchroot refindbootloaderinstall $realrootdev
   rootuuid=$(blkid -s UUID -o value $realrootdev)
@@ -1687,16 +1687,16 @@ pressanykey(){
 }
 
 loadstrings(){
-  
+
   locale=en_US.UTF-8
   #font=
-  
+
   txtexit="Exit"
   txtback="Back"
   txtignore="Ignore"
-  
+
   txtselectserver="Select source server :"
-  
+
   txtmainmenu="Main Menu"
   txtlanguage="Language"
   txtsetkeymap="Set Keyboard Layout"
@@ -1736,9 +1736,9 @@ loadstrings(){
   txtluksdevicecreated="luks device created !"
 
   txtinstallmenu="Install Menu"
-  
+
   txtarchinstallmenu="Arch Install Menu"
-  
+
   txteditmirrorlist="Edit mirrorlist"
   txtinstallarchlinux="Install Arch Linux"
   txtconfigarchlinux="Config Arch Linux"
@@ -1748,27 +1748,27 @@ loadstrings(){
   txtsetlocale="Set Locale"
   txtsettime="Set Time"
   txtsetrootpassword="Set root password"
-  
+
   txtuseutcclock="Use UTC hardware clock ?"
-  
+
   txtbootloader="Bootloader"
   txtbootloadermenu="Choose your bootloader"
-  
+
   txtefibootmgr="efibootmgr is required for EFI computers."
-  
+
   txtbootloadergrubmenu="Grub Install Menu"
   txtrungrubmakeconfig="Run grub-mkconfig ?"
   txtgrubluksdetected="Encrypted root partion !\n\nAdd cryptdevice= to GRUB_CMDLINE_LINUX in /etc/default/grub ?"
-  
+
   txtbootloadersyslinuxmenu="Syslinux Install Menu"
   txtsyslinuxaddefibootmgr="EFI install require efibootmgr"
   txtsyslinuxaddgptfdisk="GPT disk require gptfdisk"
   txtsyslinuxaddmtools="FAT boot part require mtools"
-  
+
   txtbootloadersystemdmenu="Systemd-boot Install Menu"
-  
+
   txtbootloaderrefindmenu="rEFInd Install Menu"
-  
+
   txtoptional="Optional"
   txtrecommandeasyinst="Recommanded for easy install"
   txtset="Set %1"
@@ -1776,9 +1776,9 @@ loadstrings(){
   txtedit="Edit %1"
   txtinstall="Install %1"
   txtenable="Enable %1"
-  
+
   txtpressanykey="Press any key to continue."
-  
+
   txtarchdidesc="Full desktop install script"
   txtinstallarchdi="Arch Linux Desktop Install (archdi) is a second script who can help you to install a full workstation.\n\nYou can just launch the script or install it. Choose in the next menu.\n\nArch Linux Desktop Install as two dependencies : wget and libnewt.\n\npacstrap wget libnewt ?"
   txtarchdiinstallandlaunch="Install and run archdi"

--- a/archfi
+++ b/archfi
@@ -971,7 +971,7 @@ archsetkeymap(){
 
 archsetfont(){
   items=$(find /usr/share/kbd/consolefonts/*.psfu.gz -printf "%f\n")
-
+  
   options=()
   for item in $items; do
     options+=("${item%%.*}" "")
@@ -1031,8 +1031,8 @@ archsettime(){
   if [ ! "$?" = "0" ]; then
     return 1
   fi
-
-
+  
+  
   items=$(ls /mnt/usr/share/zoneinfo/$timezone/)
   options=()
   for item in $items; do
@@ -1045,12 +1045,12 @@ archsettime(){
   if [ ! "$?" = "0" ]; then
     return 1
   fi
-
+  
   clear
   echo "ln -sf /mnt/usr/share/zoneinfo/$timezone /mnt/etc/localtime"
   ln -sf /usr/share/zoneinfo/$timezone /mnt/etc/localtime
   pressanykey
-
+  
   if (whiptail --backtitle "$apptitle" --title "$txtsettime" --yesno "$txtuseutcclock" 0 0) then
     clear
     archchroot settimeutc
@@ -1058,9 +1058,9 @@ archsettime(){
     clear
     archchroot settimelocal
   fi
-
+  
   pressanykey
-
+  
 }
 archsettimeutcchroot(){
   echo "hwclock --systohc --utc"
@@ -1223,7 +1223,7 @@ archgrubinstall(){
   echo "pacstrap /mnt grub"
   pacstrap /mnt grub
   pressanykey
-
+  
   if [ "$eficomputer" == "1" ]; then
     if [ "$efimode" == "1" ]||[ "$efimode" == "2" ]; then
       if (whiptail --backtitle "$apptitle" --title "${txtinstall//%1/efibootmgr}" --yesno "$txtefibootmgr" 0 0) then
@@ -1241,7 +1241,7 @@ archgrubinstall(){
       fi
     fi
   fi
-
+  
   if [ "$luksroot" = "1" ]; then
     if (whiptail --backtitle "$apptitle" --title "${txtinstall//%1/grub}" --yesno "$txtgrubluksdetected" 0 0) then
       clear
@@ -1250,7 +1250,7 @@ archgrubinstall(){
       pressanykey
     fi
   fi
-
+  
   clear
   archchroot grubinstall
   pressanykey
@@ -1375,12 +1375,12 @@ archbootloadersyslinuxbmenu(){
 }
 archsyslinuxinstall(){
   clear
-
+  
   if [ "$efimode" == "1" ]||[ "$efimode" == "2" ]; then
     echo "$txtsyslinuxaddefibootmgr"
     additionalpkg=$additionalpkg"efibootmgr "
   fi
-
+  
   if [ "$isnvme" = "1" ]; then
     if [ "$(parted ${realrootdev::(-2)} print|grep gpt)" != "" ]; then
       echo "$txtsyslinuxaddgptfdisk"
@@ -1392,7 +1392,7 @@ archsyslinuxinstall(){
       additionalpkg=$additionalpkg"gptfdisk "
     fi
   fi
-
+  
   if [ "$bootdev" != "" ]; then
     if [ "$(parted $bootdev print|grep fat)" != "" ]; then
       echo "$txtsyslinuxaddmtools"
@@ -1413,7 +1413,7 @@ archsyslinuxinstall(){
     echo "sed -i \"/APPEND\ root=/c\    APPEND root=$rootdev rw\" /mnt/boot/syslinux/syslinux.cfg"
     sed -i "/APPEND\ root=/c\    APPEND root=$rootdev\ rw" /mnt/boot/syslinux/syslinux.cfg
   fi
-
+  
   pressanykey
 }
 archsyslinuxinstallbootloader(){
@@ -1487,10 +1487,10 @@ archbootloadersystemdbmenu(){
 archsystemdinstall(){
   clear
   archchroot systemdbootloaderinstall $realrootdev
-
+  
   partuuid=$(blkid -s PARTUUID -o value $realrootdev)
   parttype=$(blkid -s TYPE -o value $rootdev)
-
+  
   echo "cp /mnt/usr/share/systemd/bootctl/arch.conf /mnt/boot/loader/entries"
   echo "echo \"timeout 2\" >> /mnt/boot/loader/loader.conf"
   echo "cp /mnt/usr/share/systemd/bootctl/loader.conf /mnt/boot/loader"
@@ -1506,12 +1506,12 @@ archsystemdinstall(){
   echo "cp /mnt/boot/loader/entries/arch.conf /mnt/boot/loader/entries/arch-fallback.conf"
   echo "sed -i \"s/Arch Linux/Arch Linux Fallback/\" /mnt/boot/loader/entries/arch-fallback.conf"
   echo "sed -i \"s/initramfs-linux/initramfs-linux-fallback/\" /mnt/boot/loader/entries/arch-fallback.conf"
-
+  
   cp /mnt/usr/share/systemd/bootctl/loader.conf /mnt/boot/loader
   echo "timeout 2" >> /mnt/boot/loader/loader.conf
   cp /mnt/usr/share/systemd/bootctl/arch.conf /mnt/boot/loader/entries
-
-
+  
+  
   if [ "$luksroot" = "1" ]; then
     sed -i "s/PARTUUID=XXXX/\/dev\/mapper\/root/" /mnt/boot/loader/entries/arch.conf
     sed -i "s/XXXX/$parttype/" /mnt/boot/loader/entries/arch.conf
@@ -1520,11 +1520,11 @@ archsystemdinstall(){
     sed -i "s/PARTUUID=XXXX/PARTUUID=$partuuid/" /mnt/boot/loader/entries/arch.conf
     sed -i "s/XXXX/$parttype/" /mnt/boot/loader/entries/arch.conf
   fi
-
+  
   cp /mnt/boot/loader/entries/arch.conf /mnt/boot/loader/entries/arch-fallback.conf
   sed -i "s/Arch Linux/Arch Linux Fallback/" /mnt/boot/loader/entries/arch-fallback.conf
   sed -i "s/initramfs-linux/initramfs-linux-fallback/" /mnt/boot/loader/entries/arch-fallback.conf
-
+  
   pressanykey
 }
 archsystemdinstallchroot(){
@@ -1567,13 +1567,13 @@ archbootloaderrefindmenu(){
 }
 archrefindinstall(){
   clear
-
+  
   echo "pacstrap /mnt refind-efi"
   echo "archchroot refindbootloaderinstall $realrootdev"
   echo "echo \"\\\"Arch Linux         \\\" \\\"root=UUID=$rootuuid rw add_efi_memmap\\\"\" > /mnt/boot/refind_linux.conf"
   echo "echo \"\\\"Arch Linux Fallback\\\" \\\"root=UUID=$rootuuid rw add_efi_memmap initrd=/initramfs-linux-fallback.img\\\"\" >> /mnt/boot/refind_linux.conf"
   echo "echo \"\\\"Arch Linux Terminal\\\" \\\"root=UUID=$rootuuid rw add_efi_memmap systemd.unit=multi-user.target\\\"\" >> /mnt/boot/refind_linux.conf"
-
+  
   pacstrap /mnt refind-efi
   archchroot refindbootloaderinstall $realrootdev
   rootuuid=$(blkid -s UUID -o value $realrootdev)
@@ -1687,16 +1687,16 @@ pressanykey(){
 }
 
 loadstrings(){
-
+  
   locale=en_US.UTF-8
   #font=
-
+  
   txtexit="Exit"
   txtback="Back"
   txtignore="Ignore"
-
+  
   txtselectserver="Select source server :"
-
+  
   txtmainmenu="Main Menu"
   txtlanguage="Language"
   txtsetkeymap="Set Keyboard Layout"
@@ -1736,9 +1736,9 @@ loadstrings(){
   txtluksdevicecreated="luks device created !"
 
   txtinstallmenu="Install Menu"
-
+  
   txtarchinstallmenu="Arch Install Menu"
-
+  
   txteditmirrorlist="Edit mirrorlist"
   txtinstallarchlinux="Install Arch Linux"
   txtconfigarchlinux="Config Arch Linux"
@@ -1748,27 +1748,27 @@ loadstrings(){
   txtsetlocale="Set Locale"
   txtsettime="Set Time"
   txtsetrootpassword="Set root password"
-
+  
   txtuseutcclock="Use UTC hardware clock ?"
-
+  
   txtbootloader="Bootloader"
   txtbootloadermenu="Choose your bootloader"
-
+  
   txtefibootmgr="efibootmgr is required for EFI computers."
-
+  
   txtbootloadergrubmenu="Grub Install Menu"
   txtrungrubmakeconfig="Run grub-mkconfig ?"
   txtgrubluksdetected="Encrypted root partion !\n\nAdd cryptdevice= to GRUB_CMDLINE_LINUX in /etc/default/grub ?"
-
+  
   txtbootloadersyslinuxmenu="Syslinux Install Menu"
   txtsyslinuxaddefibootmgr="EFI install require efibootmgr"
   txtsyslinuxaddgptfdisk="GPT disk require gptfdisk"
   txtsyslinuxaddmtools="FAT boot part require mtools"
-
+  
   txtbootloadersystemdmenu="Systemd-boot Install Menu"
-
+  
   txtbootloaderrefindmenu="rEFInd Install Menu"
-
+  
   txtoptional="Optional"
   txtrecommandeasyinst="Recommanded for easy install"
   txtset="Set %1"
@@ -1776,9 +1776,9 @@ loadstrings(){
   txtedit="Edit %1"
   txtinstall="Install %1"
   txtenable="Enable %1"
-
+  
   txtpressanykey="Press any key to continue."
-
+  
   txtarchdidesc="Full desktop install script"
   txtinstallarchdi="Arch Linux Desktop Install (archdi) is a second script who can help you to install a full workstation.\n\nYou can just launch the script or install it. Choose in the next menu.\n\nArch Linux Desktop Install as two dependencies : wget and libnewt.\n\npacstrap wget libnewt ?"
   txtarchdiinstallandlaunch="Install and run archdi"


### PR DESCRIPTION
'dhcpd' vs 'dhcpcd' - I found this in archdi-pkg when disabling the service doesn't succeed due to the typo. this pr fixes the text of what the command is actually doing. separate pr coming your way for archdi-pkg.

the whitespace fixes were done by atom automatically.