### PR TITLE
BTRFS change and remove unneeded Echoes

### DIFF
--- a/archfi
+++ b/archfi
@@ -13,7 +13,7 @@
 
 
 apptitle="Arch Linux Fast Install (archfi) - Version: 2020.07.16.00.57.38 (GPLv3)"
-baseurl=https://raw.githubusercontent.com/MatMoul/archfi/master
+baseurl=http://downloads.sourceforge.net/project/archfi/release/2020.07.16.00.57.38
 cpl=0
 skipfont="0"
 fspkgs=""
@@ -602,8 +602,13 @@ formatdevice(){
 				echo "btrfs subvolume set-default /mnt/root"
 				echo "umount /mnt"
 				mount ${2} /mnt
-				btrfs subvolume create /mnt/root
-				btrfs subvolume set-default /mnt/root
+				BTRFS=true
+				btrfs subvolume create /mnt/Arch
+				btrfs subvolume create /mnt/Arch/root
+				btrfs subvolume create /mnt/Arch/home
+				btrfs subvolume create /mnt/Arch/Snapshots
+				btrfs subvolume create /mnt/Arch/Snapshots/root
+				btrfs subvolume create /mnt/Arch/Snapshots/home
 				umount /mnt
 			fi
 		;;
@@ -706,8 +711,13 @@ formatdevice(){
 
 mountparts(){
 	clear
-	echo "mount ${rootdev} /mnt"
-	mount ${rootdev} /mnt
+	if [ "$BTRFS" = "true" ]; then
+		echo "mount -o subvol=Arch/root ${rootdev} /mnt"
+		mount -o subvol=Arch/root ${rootdev} /mnt
+	else
+		echo "mount ${rootdev} /mnt"
+		mount ${rootdev} /mnt
+	fi
 	echo "mkdir /mnt/{boot,home}"
 	mkdir /mnt/{boot,home} 2>/dev/null
 	if [ ! "${bootdev}" = "" ]; then
@@ -721,6 +731,10 @@ mountparts(){
 	if [ ! "${homedev}" = "" ]; then
 		echo "mount ${homedev} /mnt/home"
 		mount ${homedev} /mnt/home
+	fi
+	if [ "$BTRFS" = "true" ]; then
+		echo "mount -o subvol=Arch/home ${rootdev} /mnt/home"
+		mount -o subvol=Arch/home ${rootdev} /mnt/home
 	fi
 	pressanykey
 	installmenu

--- a/archfi
+++ b/archfi
@@ -734,6 +734,10 @@ mountparts(){
 	if [ "$BTRFS" = "true" ]; then
 		echo "mount -o subvol=Arch/home ${rootdev} /mnt/home"
 		mount -o subvol=Arch/home ${rootdev} /mnt/home
+		echo "mkdir /mnt/Arch"
+		mkdir /mnt/Arch 2>/dev/null
+		echo "mount -o subvol=Arch ${rootdev} /mnt/Arch"
+		mount -o subvol=Arch ${rootdev} /mnt/Arch
 	fi
 	pressanykey
 	installmenu

--- a/archfi
+++ b/archfi
@@ -598,17 +598,16 @@ formatdevice(){
 			mkfs.btrfs -f ${2}
 			if [ "${1}" = "root" ]; then
 				echo "mount ${2} /mnt"
-				echo "btrfs subvolume create /mnt/root"
-				echo "btrfs subvolume set-default /mnt/root"
-				echo "umount /mnt"
 				mount ${2} /mnt
 				BTRFS=true
+				echo "creating BTRFS subvolumes"
 				btrfs subvolume create /mnt/Arch
 				btrfs subvolume create /mnt/Arch/root
 				btrfs subvolume create /mnt/Arch/home
 				btrfs subvolume create /mnt/Arch/Snapshots
 				btrfs subvolume create /mnt/Arch/Snapshots/root
 				btrfs subvolume create /mnt/Arch/Snapshots/home
+				echo "umount /mnt"
 				umount /mnt
 			fi
 		;;


### PR DESCRIPTION
Added BTRFS home subvolume and Snapshot subvolumes also changed to use subvolumes as recommended on arch wiki.
Also removes some unneeded Echo commands as need information is shown in command output. 
![BTRFS-ArchWiki](https://user-images.githubusercontent.com/65131041/96353286-70f90580-10c2-11eb-91a6-b616f2a3fe9e.png)
![BTRFS-Layout](https://user-images.githubusercontent.com/65131041/96353287-70f90580-10c2-11eb-8472-6107a5bc9ce5.png)

