### PR TITLE
Replace wifi-menu with iwctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can watch my videos to see how to use it [here](https://www.youtube.com/play
 
 First, boot with the [last Arch Linux image](https://www.archlinux.org/download/) with a [bootable device](https://wiki.archlinux.org/index.php/USB_flash_installation_media).
 
-Then make sure you have Internet connection on the Arch iso. If you have a wireless connection the `wifi-menu` command might be useful to you. You can also read the [Network configuration](https://wiki.archlinux.org/index.php/Network_configuration) from the Arch Linux guide for more detailed instructions.
+Then make sure you have Internet connection on the Arch iso. If you have a wireless connection the [`iwctl`](https://wiki.archlinux.org/index.php/Iwd#iwctl) command might be useful to you. You can also read the [Network configuration](https://wiki.archlinux.org/index.php/Network_configuration) from the Arch Linux guide for more detailed instructions.
 
 Then download the script with from the command line:
 


### PR DESCRIPTION
The wifi-menu has been removed from the installation medium, now iwtcl is the preferred way