### PR TITLE
Update GPT partition numbers

### DIFF
--- a/archfi
+++ b/archfi
@@ -320,19 +320,19 @@ diskpartautoefi(){
 			echo "${txtautopartcreate//%1/swap}"
 			swapsize=$(cat /proc/meminfo | grep MemTotal | awk '{ print $2 }')
 			swapsize=$((${swapsize}/1000))"M"
-			sgdisk ${device} -n=3:0:+${swapsize} -t=3:8200
+			sgdisk ${device} -n=2:0:+${swapsize} -t=2:8200
 			echo "${txtautopartcreate//%1/root}"
-			sgdisk ${device} -n=4:0:0
+			sgdisk ${device} -n=3:0:0
 			echo ""
 			pressanykey
 			if [ "${device::8}" == "/dev/nvm" ]; then
 				bootdev=${device}"p1"
-				swapdev=${device}"p3"
-				rootdev=${device}"p4"
+				swapdev=${device}"p2"
+				rootdev=${device}"p3"
 			else
 				bootdev=${device}"1"
-				swapdev=${device}"3"
-				rootdev=${device}"4"
+				swapdev=${device}"2"
+				rootdev=${device}"3"
 			fi
 			efimode="1"
 		fi
@@ -349,9 +349,9 @@ diskpartautoefiusb(){
 			echo "${txtautopartcreate//%1/EFI boot}"
 			sgdisk ${device} -n=1:0:+1024M -t=1:ef00
 			echo "${txtautopartcreate//%1/BIOS boot}"
-			sgdisk ${device} -n=3:0:+31M -t=3:ef02
+			sgdisk ${device} -n=2:0:+31M -t=2:ef02
 			echo "${txtautopartcreate//%1/root}"
-			sgdisk ${device} -n=4:0:0
+			sgdisk ${device} -n=3:0:0
 			echo "${txthybridpartcreate}"
 			echo -e "r\nh\n3\nN\n\nY\nN\nw\nY\n" | gdisk ${device}
 			echo ""
@@ -359,11 +359,11 @@ diskpartautoefiusb(){
 			if [ "${device::8}" == "/dev/nvm" ]; then
 				bootdev=${device}"p1"
 				swapdev=
-				rootdev=${device}"p4"
+				rootdev=${device}"p3"
 			else
 				bootdev=${device}"1"
 				swapdev=
-				rootdev=${device}"4"
+				rootdev=${device}"3"
 			fi
 			efimode="2"
 		fi


### PR DESCRIPTION
This commit updates GPT partition numbers to match the order of partitions on the disk (default behavior on most installer).

Example on ArchWiki: https://wiki.archlinux.org/index.php/Partitioning#UEFI/GPT_layout_example